### PR TITLE
fix for attachments

### DIFF
--- a/Transport/ScalewayApiTransport.php
+++ b/Transport/ScalewayApiTransport.php
@@ -99,7 +99,7 @@ final class ScalewayApiTransport extends AbstractApiTransport
             $payload['html'] = $email->getHtmlBody();
         }
         if ($attachements = $this->prepareAttachments($email)) {
-            $payload['attachment'] = $attachements;
+            $payload['attachments'] = $attachements;
         }
 
         return $payload;
@@ -115,7 +115,7 @@ final class ScalewayApiTransport extends AbstractApiTransport
             $attachments[] = [
                 'name' => $filename,
                 'type' => $headers->get('Content-Type')->getBody(),
-                'content' => base64_encode($attachment->bodyToString()),
+                'content' => str_replace("\r\n", '', $attachment->bodyToString()),
             ];
         }
 


### PR DESCRIPTION
Here a pair of fixes for attachments' handling.

1) the attribute in the JSON payload is "attachments", not "attachment". Here you find the [reference documentation](https://www.scaleway.com/en/developers/api/transactional-email/#going-further)

2) as `bodyToString()` already returns a base64-encoded string, there is no need to re-encode it. I've replicated the behaviour [adopted by BrevoMailer](https://github.com/symfony/brevo-mailer/blob/7.0/Transport/BrevoApiTransport.php#L129), that I also use with profit